### PR TITLE
Fix missing newlines in npcshrc generation, fix jinx file execution

### DIFF
--- a/npcsh/_state.py
+++ b/npcsh/_state.py
@@ -821,6 +821,23 @@ def ensure_npcshrc_exists() -> str:
 
 
 
+def load_npcshrc_env() -> None:
+    """Load ~/.npcshrc exports into the current process environment."""
+    npcshrc_path = os.path.expanduser("~/.npcshrc")
+    if not os.path.exists(npcshrc_path):
+        return
+    with open(npcshrc_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith("export ") and "=" in line:
+                # export KEY='value' or export KEY=value
+                kv = line[len("export "):]
+                key, _, val = kv.partition("=")
+                val = val.strip("'\"")
+                if key and key not in os.environ:
+                    os.environ[key] = val
+
+
 def setup_npcsh_config() -> None:
     """
     Function Description:
@@ -834,6 +851,7 @@ def setup_npcsh_config() -> None:
     """
 
     ensure_npcshrc_exists()
+    load_npcshrc_env()
     add_npcshrc_to_shell_config()
 
 

--- a/npcsh/_state.py
+++ b/npcsh/_state.py
@@ -793,7 +793,7 @@ def ensure_npcshrc_exists() -> str:
             npcshrc.write("# NPCSH Configuration File\n")
             npcshrc.write("export NPCSH_INITIALIZED=0\n")
             npcshrc.write("export NPCSH_DEFAULT_MODE='agent'\n")
-            npcshrc.write("export NPCSH_BUILD_KG=1")
+            npcshrc.write("export NPCSH_BUILD_KG=1\n")
             npcshrc.write("export NPCSH_CHAT_PROVIDER='ollama'\n")
             npcshrc.write("export NPCSH_CHAT_MODEL='gemma3:4b'\n")
             npcshrc.write("export NPCSH_REASONING_PROVIDER='ollama'\n")
@@ -816,7 +816,7 @@ def ensure_npcshrc_exists() -> str:
             npcshrc.write("export NPCSH_API_URL=''\n")
             npcshrc.write("export NPCSH_DB_PATH='~/npcsh_history.db'\n")
             npcshrc.write("export NPCSH_VECTOR_DB_PATH='~/npcsh_chroma.db'\n")
-            npcshrc.write("export NPCSH_STREAM_OUTPUT=0")
+            npcshrc.write("export NPCSH_STREAM_OUTPUT=0\n")
     return npcshrc_path
 
 

--- a/npcsh/npc.py
+++ b/npcsh/npc.py
@@ -83,8 +83,15 @@ def _exec_jinx_file(jinx_path: str, args: list):
                 input_values[name] = arg
                 positional_idx += 1
 
+    # Set up NPC team so jinx steps have access to npc object
+    forenpc_obj = None
     try:
-        result = jinx.execute(input_values=input_values)
+        _, team, forenpc_obj = setup_shell()
+    except Exception as e:
+        print(f"Warning: Could not set up NPC team: {e}", file=sys.stderr)
+
+    try:
+        result = jinx.execute(input_values=input_values, npc=forenpc_obj)
         output = result.get('output', '') if isinstance(result, dict) else str(result)
         if output:
             print(output)


### PR DESCRIPTION
Fix missing \n in ensure_npcshrc_exists() for NPCSH_BUILD_KG and NPCSH_STREAM_OUTPUT exports. Fix _exec_jinx_file to handle jinx files without shebang lines.