### PR TITLE
fix: update get_genai_response to npcrs 0.1.2 signature

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1058,7 +1058,7 @@ async fn exec_npc_file(npc_file: &str, command: Option<&str>) -> Result<()> {
             npcrs::Message::user(cmd),
         ];
         let response = npcrs::r#gen::get_genai_response
-            (&provider, &model, &messages, None, npc.api_url.as_deref())
+            (&provider, &model, &messages, None, npc.api_url.as_deref(), None, None, false, None)
             .await?;
         if let Some(text) = response.message.content {
             println!("{}", text);


### PR DESCRIPTION
- `get_genai_response` in published npcrs 0.1.2 takes 9 args (added `format`, `images`, `stream`, `think`); was passing 5