### PR TITLE
fix: version shows 0.0.0 when installed from crates.io

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     let version = std::fs::read_to_string("../VERSION")
-        .unwrap_or_else(|_| "0.0.0".to_string())
+        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string())
         .trim()
         .to_string();
     println!("cargo:rustc-env=NPCSH_VERSION={}", version);


### PR DESCRIPTION
- build.rs falls back to CARGO_PKG_VERSION when ../VERSION file is absent (e.g. cargo install from crates.io)