### PR TITLE
Fix: CWD handling in benchmark runners and add NPCSH_ENGINE to template

### DIFF
--- a/npcsh/_state.py
+++ b/npcsh/_state.py
@@ -986,6 +986,7 @@ def ensure_npcshrc_exists() -> str:
             npcshrc.write("export NPCSH_DB_PATH='~/npcsh_history.db'\n")
             npcshrc.write("export NPCSH_VECTOR_DB_PATH='~/npcsh_chroma.db'\n")
             npcshrc.write("export NPCSH_STREAM_OUTPUT=0\n")
+            npcshrc.write("export NPCSH_ENGINE='python'\n")
     return npcshrc_path
 
 


### PR DESCRIPTION
- Add NPCSH_ENGINE to default npcshrc template
- Fix chdir in local runner
- Fix framework runner cwd handling