### PR TITLE
Bump Rust crate version to 0.0.1

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "npcsh"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2024"
 description = "The composable multi-agent shell"
 license = "MIT"


### PR DESCRIPTION
Bump Rust crate version to 0.0.1 for crates.io publish