### PR TITLE
fix: resolve CI failures after main merge

### DIFF
--- a/npcsh/_state.py
+++ b/npcsh/_state.py
@@ -105,7 +105,7 @@ from npcpy.memory.command_history import (
     load_kg_from_db,
 )
 from npcpy.memory.search import execute_rag_command, execute_brainblast_command
-from npcpy.npc_compiler import NPC, CLIAgent, _is_cli_provider, Team, build_jinx_tool_catalog
+from npcpy.npc_compiler import NPC, CLIAgent, Team, build_jinx_tool_catalog
 from npcpy.tools import flatten_tool_messages
 from npcpy.npc_sysenv import (
     print_and_process_stream_with_markdown,

--- a/npcsh/ui.py
+++ b/npcsh/ui.py
@@ -151,7 +151,7 @@ class BottomBar:
                                         f.write(f"  read2: {ch2!r}\n")
                             else:
                                 with open("/tmp/bottombar_debug.log", "a") as f:
-                                    f.write(f"  select timeout, no chars\n")
+                                    f.write("  select timeout, no chars\n")
                         except Exception as e:
                             with open("/tmp/bottombar_debug.log", "a") as f:
                                 f.write(f"  exception: {e}\n")

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -305,7 +305,8 @@ async fn main() -> Result<()> {
     let mut session_cost: f64 = 0.0;
     let session_start = std::time::Instant::now();
     // CLI session IDs keyed by (provider, npc_name) for session continuity.
-    let mut cli_sessions: std::collections::HashMap<(String, String), String> = std::collections::HashMap::new();
+    // TODO: re-enable once npcrs publishes CLI provider support.
+    // let mut cli_sessions: std::collections::HashMap<(String, String), String> = std::collections::HashMap::new();
 
     let daemon_handle = std::sync::Arc::new(tokio::sync::Mutex::new(Some(daemon_handle)));
 
@@ -676,39 +677,9 @@ async fn main() -> Result<()> {
         let cwd = std::env::current_dir().map(|p| p.display().to_string()).unwrap_or_else(|_| ".".to_string());
 
         // CLI provider routing — intercept before kernel.exec when provider is a CLI tool.
-        let cli_intercepted = if npcrs::llm_funcs::CLI_PROVIDERS.contains(&provider_str.as_str()) {
-            let cli_key = (provider_str.clone(), npc_name_str.clone());
-            let sid = cli_sessions.get(&cli_key).map(String::as_str);
-            let system_prompt = kernel
-                .get_process(current_pid)
-                .map(|p| p.npc.system_prompt(None))
-                .unwrap_or_else(|| "You are a helpful assistant.".to_string());
-            let cli_result = npcrs::llm_funcs::run_cli_provider(
-                &provider_str,
-                &model_str,
-                &input,
-                &system_prompt,
-                sid,
-                &npc_name_str,
-                true,  // TODO: respect NPCSH_STREAM_OUTPUT once threaded through
-            )
-            .await;
-            if let Some(result) = cli_result {
-                if let Some(new_sid) = result.session_id {
-                    cli_sessions.insert(cli_key, new_sid);
-                }
-                if let Some(u) = &result.usage {
-                    session_input_tokens += u.input_tokens;
-                    session_output_tokens += u.output_tokens;
-                }
-                session_cost += result.cost_usd;
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
+        // TODO: re-enable once npcrs publishes CLI_PROVIDERS + run_cli_provider
+        // (depends on NPC-Worldwide/npcrs#2 and NPC-Worldwide/npcpy#235).
+        let cli_intercepted = false;
 
         let exec_result = if cli_intercepted {
             None // output already printed by run_cli_provider

--- a/tests/test_jinxes.py
+++ b/tests/test_jinxes.py
@@ -44,10 +44,10 @@ def test_jinx_has_required_fields(jinx_file):
 
 def test_search_jinxes_exist():
     """Test that the search jinxes exist."""
-    lib_dir = os.path.join(
-        os.path.dirname(__file__), '..', 'npcsh', 'npc_team', 'jinxes', 'lib',
+    search_dir = os.path.join(
+        os.path.dirname(__file__), '..', 'npcsh', 'npc_team', 'jinxes', 'lib', 'search',
     )
 
-    assert os.path.exists(os.path.join(lib_dir, 'web_search.jinx'))
-    assert os.path.exists(os.path.join(lib_dir, 'file_search.jinx'))
-    assert os.path.exists(os.path.join(lib_dir, 'db_search.jinx'))
+    assert os.path.exists(os.path.join(search_dir, 'web_search.jinx'))
+    assert os.path.exists(os.path.join(search_dir, 'file_search.jinx'))
+    assert os.path.exists(os.path.join(search_dir, 'db_search.jinx'))


### PR DESCRIPTION
## Summary

Fixes CI failures that appeared after merging the providers + CLI providers PRs into main.

## Changes

- **Lint:** Remove unused `_is_cli_provider` import (F401) and fix f-string without placeholders in `ui.py` (F541)
- **Tests:** Update `test_jinxes.py` to look in `lib/search/` subdirectory for search jinxes (files were reorganized in a prior PR)
- **Rust:** Comment out CLI provider intercept block in `rust/src/main.rs` until `npcrs` publishes `CLI_PROVIDERS` + `run_cli_provider` (depends on NPC-Worldwide/npcrs#2). This unblocks `cargo publish` in the release workflow.

## Test plan

- [x] `pytest tests/` passes locally (128 passed, 2 skipped)
- [x] `ruff check npcsh/` passes with no errors