### PR TITLE
Fix lint: remove unused platform import

### DIFF
--- a/npcsh/version_check.py
+++ b/npcsh/version_check.py
@@ -1,6 +1,5 @@
 import json
 import os
-import platform
 import shutil
 import subprocess
 import threading


### PR DESCRIPTION
Fixes ruff F401 lint failure in version_check.py.