### PR TITLE
Fix test_mixed_provider_types: make forenpc selection deterministic

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -778,6 +778,7 @@ class TestCombinedProviderScenarios:
 
         team_ctx = {
             "context": "test",
+            "forenpc": "forenpc",
             "providers": [
                 {
                     "name": "anthropic_cloud",


### PR DESCRIPTION
Fixes a non-deterministic test failure where os.listdir order on Linux CI caused forenpc to resolve to 'coder' instead of 'forenpc'. Adding 'forenpc': 'forenpc' to team_ctx makes the selection explicit.