### PR TITLE
Drop macos-13 from launcher-smoke CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub is phasing out Intel macOS runners (macos-13) and they are chronically backlogged, causing 20+ minute queue times. macos-14 (ARM64) already covers macOS. Keeps ubuntu-latest, macos-14, and windows-latest for the smoke test matrix.