### PR TITLE
fix: brew detection unreachable in version_check._detect_source

### DIFF
--- a/npcsh/version_check.py
+++ b/npcsh/version_check.py
@@ -33,20 +33,22 @@ class VersionCheck:
         except Exception:
             pass
 
-        # If npcrs binary is on PATH and we're the Rust build → cargo
-        cargo_bin = shutil.which("npcrs") or shutil.which("npcsh")
-        if cargo_bin:
-            return "cargo"
+        binary = shutil.which("npcrs") or shutil.which("npcsh")
 
-        # If binary is under Homebrew paths → brew
+        # Check Homebrew before Cargo: a binary under a Homebrew prefix was
+        # installed via brew, not cargo install.  The original code returned
+        # "cargo" unconditionally whenever any binary was found, making the
+        # Homebrew branch unreachable dead code.
         brew_paths = [
             "/opt/homebrew",
             "/usr/local",
             "/home/linuxbrew",
         ]
-        for bp in brew_paths:
-            if cargo_bin and cargo_bin.startswith(bp):
-                return "brew"
+        if binary:
+            for bp in brew_paths:
+                if binary.startswith(bp):
+                    return "brew"
+            return "cargo"
 
         return "pip"  # Default assumption
 


### PR DESCRIPTION
## Bug

`_detect_source()` in `version_check.py` returned `"cargo"` unconditionally whenever any binary was found on `PATH`, making the Homebrew prefix check dead code:

```python
# Before — brew check never reached
cargo_bin = shutil.which("npcrs") or shutil.which("npcsh")
if cargo_bin:
    return "cargo"   # ← always exits here

# If binary is under Homebrew paths → brew  (NEVER RUNS)
for bp in brew_paths:
    if cargo_bin and cargo_bin.startswith(bp):
        return "brew"
```

Binaries installed via `brew install npcsh` live under `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew`. They were incorrectly classified as `"cargo"`, so the update banner told Homebrew users to run `cargo install npcsh --force` instead of `brew upgrade npcsh`.

## Fix

Check Homebrew prefix **before** falling through to `"cargo"`:

```python
binary = shutil.which("npcrs") or shutil.which("npcsh")
if binary:
    for bp in brew_paths:
        if binary.startswith(bp):
            return "brew"   # ← now reachable
    return "cargo"
```